### PR TITLE
Use transactions around prepared statements for expo sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Expo sqlite does not support batching of queries out the box. Prepared statement
 
 #### Steps to setup the library:
 
-- `yarn remove @journeyapps/react-native-quick-sqlite`
+- `yarn remove @powersync/react-native-quick-sqlite`
 - `yarn add react-native-quick-sqlite`
 - From Expo 51 onwards a patch is required to compile RNQS `yarn patch-package`
 - Comment out the code in the file referencing PowersyncSqliteAdapter which includes `adapters/powersync-sqlite-adapter.ts`. Also comment out lines 6, 23 and 27 in `App.tsx`.

--- a/adapters/expo-sqlite-adapter.ts
+++ b/adapters/expo-sqlite-adapter.ts
@@ -38,13 +38,15 @@ export class ExpoSqliteAdapter extends AbstractDBAdapter {
   }
 
   async executeBatch(commands: SQLBatchTuple[]): Promise<ResultSet> {
-    const statement = await this.db.prepareAsync(commands[0][0]);
-    for (const tuple of commands) {
-      const params = tuple[1];
-      await statement.executeAsync(params as any[]);
-    }
-    await statement.finalizeAsync();
-    // Result is not used
+    await this.transaction(async (tx) => {
+      const statement = await this.db.prepareAsync(commands[0][0]);
+      for (const tuple of commands) {
+        const params = tuple[1];
+        await statement.executeAsync(params as any[]);
+      }
+      await statement.finalizeAsync();
+    });
+    //Result is not used
     return {};
   }
 

--- a/adapters/powersync-sqlite-adapter.ts
+++ b/adapters/powersync-sqlite-adapter.ts
@@ -1,5 +1,5 @@
 import { AbstractDBAdapter, ResultSet, SQLBatchTuple, TransactionCallback } from '../interface/db_adapter';
-import { QuickSQLiteConnection, open } from '@journeyapps/react-native-quick-sqlite';
+import { QuickSQLiteConnection, open } from '@powersync/react-native-quick-sqlite';
 import { deleteDbFile, getDbPath } from '../database/utils';
 
 const DB_NAME = 'powersync-sqlite';


### PR DESCRIPTION
## Work done

- Wrap prepared statements in a transaction for expo-sqlite
- Update README to `@powersync/react-native-quick-sqlite` package rename